### PR TITLE
Fix ffmpeg download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - FFMPEG is always invoked with `-threads 1` to limit the CPU usage
+- Update to FFMPEG 3.3.4
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "binaries": {
-    "ffmpeg": "3.3.3",
+    "ffmpeg": "3.3.4",
     "packager": "1.6.2"
   }
 }

--- a/src/commands/fetch-binaries.js
+++ b/src/commands/fetch-binaries.js
@@ -15,7 +15,7 @@ const FFMPEG_DOWNLOAD_URL = {
     "https://ffmpeg.zeranoe.com/builds/win{architecture}/static/ffmpeg-{version}-win{architecture}-static.zip",
   // "macos": ["https://evermeet.cx/ffmpeg/ffmpeg-{version}.7z", "https://evermeet.cx/ffmpeg/ffprobe-{version}.7z"],
   linux:
-    "https://johnvansickle.com/ffmpeg/releases/ffmpeg-{version}-{architecture}bit-static.tar.xz"
+    "https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-{version}-{architecture}bit-static.tar.xz"
 };
 
 const SHAKA_PACKAGER_DOWNLOAD_URL = {

--- a/src/helpers/download.js
+++ b/src/helpers/download.js
@@ -38,12 +38,21 @@ module.exports = function(fileUrl, path) {
         : -1;
       var downloaded = 0;
 
+      if (res.statusCode != 200) {
+        res.destroy();
+        file.close();
+        fs.unlinkSync(path);
+        reject("HTTP request failed with code " + res.statusCode);
+      }
+
       res
         .on("data", function(chunk) {
-          file.write(chunk);
-          downloaded += chunk.length;
-          clearTimeout(timeoutId);
-          timeoutId = setTimeout(fn, timeout);
+          if (file.writable) {
+            file.write(chunk);
+            downloaded += chunk.length;
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(fn, timeout);
+          }
         })
         .on("end", function() {
           // clear timeout


### PR DESCRIPTION
- Better handling of 404 errors
- Move to ffmpeg 3.3.4 as 3.3.3 cannot be downloaded anymore for Linux OS