### PR TITLE
Update ffmpeg to 4.3.1, improve existence check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         npm config set cache .npm-cache
         npm ci
         npm run run install
-        ls ./bin
+        ls -la ./bin
         
     - name: Run Testsuite
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,6 @@ jobs:
       with:
         path: bin
         key: binaries-${{matrix.os}}-${{ matrix.node-version }}-${{ hashFiles('package.json') }}
-
-    - name: Use own cache server
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo "CI_CACHE_DOMAIN=https://cache.oneofftech.xyz/" >> $GITHUB_ENV
       
     - name: Prepare environment
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
         npm config set cache .npm-cache
         npm ci
         npm run run install
-        ls -la ./bin
         
     - name: Run Testsuite
       run: |

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The binaries are generated for 64 bit version of the OS
 
 In order to use the video-processing-cli you need
 
-- [FFMPEG](https://ffmpeg.org/) version 3.3.3 or above
-- [Shaka Packager](https://github.com/google/shaka-packager/releases) version 1.6.2 or above
+- [FFMPEG](https://ffmpeg.org/) version 4.3.1 or above
+- [Shaka Packager](https://github.com/google/shaka-packager/releases) version 1.6.2
 
 The binaries can be added to the shell/command line PATH or in a `bin` folder. 
 The `bin` folder must be in the same working directory where the 
@@ -44,18 +44,22 @@ Binaries are automatically built for each tagged release.
 
 Alternatively a docker image is available, see [Usage via Docker](#via-docker-image).
 
-**Fetching the requirements**
+**Download FFMPEG and Shaka Packager executables**
 
-If you don't have already FFMPEG and Shaka Packager on your system, you can run
+Download or install FFMPEG and Shaka Packager on your system.
+Installation procedure may vary depending on the Operating System, but you can download
+a standalone binary from https://ffmpeg.org/download.html. Once downloaded place
+the binaries in the `bin` directory.
+
+The Video Processing Cli can download binaries from a mirror site by executing
 
 ```bash
 $ video-processing-cli fetch:binaries
 ```
 
-This will download the standalone, statically linked, binaries. 
-The downloaded version is based on your Operating System and architecture (32 or 64 bit).
-
-> A note for **MacOS** users: we currently don't support the automated download of FFMPEG. Pull requests are accepted.
+This will attempt to download a standalone, statically linked, version of FFMPEG, FFPROBE 
+and Shaka Packager for your operating system. The downloaded version requires a 64bit 
+architecture and is not compatible with ARM or Apple Silicon.
 
 ### Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video-processing-cli",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1555,11 +1555,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "cross-unzip": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cross-unzip/-/cross-unzip-0.2.1.tgz",
-      "integrity": "sha1-Ae0dS7JDujObLD8Dxbp6eIGJhMY="
     },
     "cssom": {
       "version": "0.4.4",
@@ -6224,11 +6219,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
-    },
-    "win-7zip": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/win-7zip/-/win-7zip-0.1.1.tgz",
-      "integrity": "sha1-FFU/bcVgA9mhcvH7XEiMfxZ+x94="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,10 @@
   "dependencies": {
     "cli-color": "^2.0.0",
     "commander": "^6.0.0",
-    "cross-unzip": "^0.2.1",
     "follow-redirects": "^1.13.0",
     "fs-extra": "^9.0.1",
     "posterus": "^0.4.7",
-    "which": "^2.0.2",
-    "win-7zip": "^0.1.1"
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "eslint": "^7.7.0",
@@ -61,7 +59,35 @@
     ]
   },
   "binaries": {
-    "ffmpeg": "3.3.4",
-    "packager": "1.6.2"
+    "ffmpeg": {
+      "win": "https://gitlab.com/avvertix/ffmpeg-binaries/-/package_files/5777246/download",
+      "linux": "https://gitlab.com/avvertix/ffmpeg-binaries/-/package_files/5777248/download",
+      "macos": "https://gitlab.com/avvertix/ffmpeg-binaries/-/package_files/5777244/download"
+    },
+    "ffprobe": {
+      "win": "https://gitlab.com/avvertix/ffmpeg-binaries/-/package_files/5777247/download",
+      "linux": "https://gitlab.com/avvertix/ffmpeg-binaries/-/package_files/5777249/download",
+      "macos": "https://gitlab.com/avvertix/ffmpeg-binaries/-/package_files/5777245/download"
+    },
+    "packager": {
+      "win": "https://github.com/google/shaka-packager/releases/download/v1.6.2/packager-win.exe",
+      "macos": "https://github.com/google/shaka-packager/releases/download/v1.6.2/packager-osx",
+      "linux": "https://github.com/google/shaka-packager/releases/download/v1.6.2/packager-linux"
+    },
+    "ffmpeg_checksum": {
+      "win": "64310dd7ade81d62c7ac2b044467989ed4b4f3cd2fa483c8e0debcf05063343a",
+      "linux": "e1c8c3c8c2073d9f83a8d74423c3eff79eaaa4227ca427720cab314eee1d7c57",
+      "macos": "91a0558aed6496a1bdd82ac0fcd70393198c0de03c386c9a0b1e4e467ea3f999"
+    },
+    "ffprobe_checksum": {
+      "win": "93bba8543157026cf72308454414e6ccefac9984aac4f1a0eccb9e1d5fbb0890",
+      "linux": "c0b7a30d3f199f4cda1279cc57ae21cd09559d4bb374a2f763a57d279d23d12d",
+      "macos": "3e10d94a766827d86857d3e6df0e9ef5b447b0855636ccf8bac56d6f80fb50ad"
+    },
+    "packager_checksum": {
+      "win": "e7d8d731685c18cddc15eb2ae343576ded16314f26a5244784e031369a646bef",
+      "macos": "acad4f7992f9509813c20bb22f5238a41774684cce727a76dd642fcef7db7dd4",
+      "linux": "cc19506eb315c79888e534f74a3938fda8e192c775579c841792553afb7c00a2"
+    }
   }
 }

--- a/src/commands/fetch-binaries.js
+++ b/src/commands/fetch-binaries.js
@@ -7,35 +7,8 @@ const Package = require("../../package.json");
 const Path = require("path");
 const fs = require("fs");
 const fse = require("fs-extra");
-const { unzip } = require("cross-unzip");
-const exec = require("child_process").exec;
+const crypto = require("crypto");
 
-const FFMPEG_DOWNLOAD_PATH = {
-  win:
-    "builds/win{architecture}/static/ffmpeg-{version}-win{architecture}-static.zip",
-  macos: 
-    "builds/macos{architecture}/static/ffmpeg-{version}-macos{architecture}-static.zip",
-  linux:
-    "ffmpeg/old-releases/ffmpeg-{version}-{architecture}bit-static.tar.xz"
-};
-
-const FFMPEG_DOWNLOAD_DOMAINS = {
-  win:
-    "https://ffmpeg.zeranoe.com/",
-  macos: 
-    "https://ffmpeg.zeranoe.com/",
-  linux:
-    "https://www.johnvansickle.com/"
-};
-
-const SHAKA_PACKAGER_DOWNLOAD_URL = {
-  win:
-    "https://github.com/google/shaka-packager/releases/download/v{version}/packager-win.exe",
-  macos:
-    "https://github.com/google/shaka-packager/releases/download/v{version}/packager-osx",
-  linux:
-    "https://github.com/google/shaka-packager/releases/download/v{version}/packager-linux"
-};
 
 /**
  * Downloads the Shaka Packager binary
@@ -44,219 +17,119 @@ const SHAKA_PACKAGER_DOWNLOAD_URL = {
  * @return {Promise}
  */
 function downloadShakaPackager(platform) {
-  var packagerUrl = SHAKA_PACKAGER_DOWNLOAD_URL[platform].replace(
-    /\{version\}/g,
-    Package.binaries.packager
-  );
+  var url = Package.binaries.packager[platform] || null;
+  var checksum = Package.binaries.packager_checksum[platform] || null;
+  var name = Path.basename(url);
 
-  if(fse.existsSync("./bin/" + Path.basename(packagerUrl))){
-    Log.info("Shaka Packager already existing");
-    return Promise.resolve(null);
-  }  
-
-  return new Downloader(packagerUrl, "./bin/" + Path.basename(packagerUrl))
-    .then(function(f) {
-      
-      if(platform === 'linux'){
-        try{
-
-          fs.chmodSync(f, 777);
-          Log.info("Shaka Packager execution permission set for ", f);
-        }
-        catch(err){
-          Log.error("Failed to set execution permission for Shaka Packager", err);
-        }
-      }
-      Log.success("Shaka Packager downloaded in", f);
-    })
-    .catch(function(err) {
-      Log.error("Shaka Packager not downloaded,", err);
-    });
+  return getBinary(name, url, checksum, platform);
 }
 
 /**
- * Downloads the FFMPEG and FFPROBE binaries
+ * Downloads the FFMPEG binary
  * 
  * @param {string} platform the platform, supported values are "win", "macos" "linux"
- * @param {string} architecture the architecture, supported values are "64" (for 64bit architecture)
  * @return {Promise}
  */
-function downloadFfmpeg(platform, architecture) {
-  if (!FFMPEG_DOWNLOAD_DOMAINS[platform] && !FFMPEG_DOWNLOAD_PATH[platform] ) {
+function downloadFfmpeg(platform) {
+
+  var ffmpegUrl = Package.binaries.ffmpeg[platform] || null;
+  var ffmpegChecksum = Package.binaries.ffmpeg_checksum[platform] || null;
+  var ffmpegBinName = "ffmpeg" + (platform === "win" ? ".exe" : "");
+
+  return getBinary(ffmpegBinName, ffmpegUrl, ffmpegChecksum, platform);
+}
+
+/**
+ * Downloads the FFPROBE binary
+ * 
+ * @param {string} platform the platform, supported values are "win", "macos" "linux"
+ * @return {Promise}
+ */
+function downloadFfprobe(platform) {
+
+  var url = Package.binaries.ffprobe[platform] || null;
+  var checksum = Package.binaries.ffprobe_checksum[platform] || null;
+  var name = "ffprobe" + (platform === "win" ? ".exe" : "");
+
+  return getBinary(name, url, checksum, platform);
+}
+
+/**
+ * Downloads a binary
+ * 
+ * @param {string} name binary name
+ * @param {string} url the url from which download the binary
+ * @param {string} checksum the sha256 checksum of the expected binary
+ * @return {Promise}
+ */
+function getBinary(name, url, checksum, platform) {
+
+  var path = "./bin/" + name;
+
+  if (! url) {
     Log.error(
-      "FFMPEG download aborted: platform not supported",
-      "(" + platform + ")"
+      name + " download aborted: platform not supported or url not provided"
     );
     return Promise.resolve(null);
   }
 
-  var domain = process.env.CI_CACHE_DOMAIN || FFMPEG_DOWNLOAD_DOMAINS[platform];
+  return checkFile(path).then(function(calculatedChecksum){
 
-  var ffmpegUrl = domain + FFMPEG_DOWNLOAD_PATH[platform]
-    .replace(/\{architecture\}/g, architecture)
-    .replace(/\{version\}/g, Package.binaries.ffmpeg);
+    if(calculatedChecksum === checksum){
+      Log.info(name + " already existing");
+      return Promise.resolve(null);
+    }
 
-  Log.info(domain);
+    Log.warning("Downloading " + name + "...");
 
-  if(fse.existsSync("./bin/ffmpeg" + (platform === "win" ? ".exe" : "")) && 
-      fse.existsSync("./bin/ffprobe" + (platform === "win" ? ".exe" : "")) ){
-    Log.info("FFMPEG already existing");
-    return Promise.resolve(null);
-  }
+    fse.renameSync(path, path + ".old");
 
-  return new Downloader(ffmpegUrl, "./bin/" + Path.basename(ffmpegUrl))
-    .then(function(f) {
-      Log.success("FFMPEG downloaded in", f);
-
-      // extract the compressed archive content
-      Log.comment("Extracting ffmpeg binaries...");
-
-      if(platform === "win"){
-        return extractFfmpegWindows("./bin/" + Path.basename(ffmpegUrl), "./bin/");
-      }
-      
-      if(platform === "macos"){
-        return extractFfmpegMacos("./bin/" + Path.basename(ffmpegUrl), "./bin/");
-      }
-
-      return extractFfmpegLinux(
-            Path.join(process.cwd(), "bin", Path.basename(ffmpegUrl)),
-            Path.join(process.cwd(), "bin")
-          );
-    })
-    .catch(function(err) {
-      Log.error("FFMPEG not downloaded,", err);
-      throw new Error("FFMPEG not downloaded");
-    });
+    return new Downloader(url, path)
+      .then(function(f) {
+        
+        if(platform === 'linux'){
+          try{
+            fs.chmodSync(f, 777);
+            Log.info("Execution permission set for ", f);
+          }
+          catch(err){
+            Log.error("Failed to set execution permission for ", err);
+          }
+        }
+        Log.success(name + " downloaded in", f);
+      })
+      .catch(function(err) {
+        Log.error(name + " not downloaded,", err);
+        throw new Error(name + " not downloaded");
+      });
+  });
 }
 
-function extractFfmpegWindows(file, path) {
-  return new Promise(function(resolve, reject) {
-    unzip(file, path, function(err) {
-      if (err) {
-        Log.error("unzip error", err.message);
-        reject(err);
-      }
 
-      fse.copySync(
-        Path.join(
-          path,
-          Path.basename(file).replace(Path.extname(file), ""),
-          "bin",
-          "ffmpeg.exe"
-        ),
-        Path.join(path, "ffmpeg.exe"),
-        { overwrite: true }
-      );
-      fse.copySync(
-        Path.join(
-          path,
-          Path.basename(file).replace(Path.extname(file), ""),
-          "bin",
-          "ffprobe.exe"
-        ),
-        Path.join(path, "ffprobe.exe"),
-        { overwrite: true }
-      );
+/**
+ * Calculate the SHA-256 checksum of a file
+ * @param {string} path 
+ * @return {Promise}
+ */
+function checkFile(path) {
 
-      fse.removeSync(
-        Path.join(path, Path.basename(file).replace(Path.extname(file), ""))
-      );
-      fse.removeSync(file);
-      resolve(null);
-    });
+  return new Promise((resolve, reject) => {
+
+    if(! fse.existsSync(path)){
+      resolve(null)
+    }
+
+    fs.createReadStream(path)
+      .on('error', reject)
+      .pipe(crypto.createHash('sha256')
+        .setEncoding('hex'))
+      .once('finish', function () {
+        resolve(this.read())
+      })
   })
-    .then(function() {
-      Log.success("FFMPEG binaries extracted from archive");
-    })
-    .catch(function(err) {
-      Log.error("Failed to extract FFMPEG binaries:", err.message);
-      throw new Error("Failed to extract FFMPEG binaries:", err.message);
-    });
 }
 
-function extractFfmpegMacos(file, path) {
-  return new Promise(function(resolve, reject) {
-    unzip(file, path, function(err) {
-      if (err) {
-        Log.error("unzip error", err.message);
-        reject(err);
-      }
 
-      fse.copySync(
-        Path.join(
-          path,
-          Path.basename(file).replace(Path.extname(file), ""),
-          "bin",
-          "ffmpeg"
-        ),
-        Path.join(path, "ffmpeg"),
-        { overwrite: true }
-      );
-      fse.copySync(
-        Path.join(
-          path,
-          Path.basename(file).replace(Path.extname(file), ""),
-          "bin",
-          "ffprobe"
-        ),
-        Path.join(path, "ffprobe"),
-        { overwrite: true }
-      );
-
-      fse.removeSync(
-        Path.join(path, Path.basename(file).replace(Path.extname(file), ""))
-      );
-      fse.removeSync(file);
-      resolve(null);
-    });
-  })
-    .then(function() {
-      Log.success("FFMPEG binaries extracted from archive");
-    })
-    .catch(function(err) {
-      Log.error("Failed to extract FFMPEG binaries:", err.message);
-      throw new Error("Failed to extract FFMPEG binaries:", err.message);
-    });
-}
-
-function extractFfmpegLinux(file, path) {
-  return new Promise(function(resolve, reject) {
-    var command = `tar -xvJf "${file}" -C "${path}"`;
-
-    var untar = exec(command, (err, stdout, stderr) => {
-      if (err) {
-        // node couldn't execute the command
-        reject(err);
-        return;
-      }
-
-      fse.copySync(
-        Path.join(path, Path.basename(file).replace(".tar.xz", ""), "ffmpeg"),
-        Path.join(path, "ffmpeg"),
-        { overwrite: true }
-      );
-      fse.copySync(
-        Path.join(path, Path.basename(file).replace(".tar.xz", ""), "ffprobe"),
-        Path.join(path, "ffprobe"),
-        { overwrite: true }
-      );
-
-      fse.removeSync(
-        Path.join(path, Path.basename(file).replace(".tar.xz", ""))
-      );
-      fse.removeSync(file);
-      resolve(null);
-    });
-  })
-    .then(function() {
-      Log.success("FFMPEG binaries extracted from archive");
-    })
-    .catch(function(err) {
-      Log.error("Failed to extract FFMPEG binaries:", err);
-      throw new Error("Failed to extract FFMPEG binaries:", err.message);
-    });
-}
 
 /**
  * Fetches the required FFMPEG and Shaka Packager binaries
@@ -269,7 +142,6 @@ module.exports = function(command) {
     const platformNormalized = process.platform.match(/win(32|64)/)
       ? "win"
       : process.platform.match(/darwin/) ? "macos" : "linux";
-    const architectureNormalized = process.arch.replace("x", "");
 
     if (!fs.existsSync("./bin")) {
       fs.mkdirSync("./bin");
@@ -277,13 +149,13 @@ module.exports = function(command) {
 
     Log.comment(
       "Downloading binaries",
-      "(" + platformNormalized + ", " + architectureNormalized + " bit)..."
+      "(" + platformNormalized + ")..."
     );
 
     return Promise.all([
       downloadShakaPackager(platformNormalized),
-
-      downloadFfmpeg(platformNormalized, architectureNormalized)
+      downloadFfmpeg(platformNormalized),
+      downloadFfprobe(platformNormalized)
     ]);
   } catch (error) {
     Log.error(error.message);

--- a/src/commands/fetch-binaries.js
+++ b/src/commands/fetch-binaries.js
@@ -91,7 +91,7 @@ function getBinary(name, url, checksum, platform) {
         
         if(platform === 'linux'){
           try{
-            fs.chmodSync(f, 777);
+            fs.chmodSync(f, 644);
             Log.info("Execution permission set for ", f);
           }
           catch(err){

--- a/src/commands/fetch-binaries.js
+++ b/src/commands/fetch-binaries.js
@@ -89,7 +89,7 @@ function getBinary(name, url, checksum, platform) {
     return new Downloader(url, path)
       .then(function(f) {
         
-        if(platform === 'linux'){
+        if(platform === 'linux' || platform === 'macos'){
           try{
             fs.chmodSync(f, 0o775);
             Log.info("Permissions set for ", f);

--- a/src/commands/fetch-binaries.js
+++ b/src/commands/fetch-binaries.js
@@ -82,7 +82,9 @@ function getBinary(name, url, checksum, platform) {
 
     Log.warning("Downloading " + name + "...");
 
-    fse.renameSync(path, path + ".old");
+    if(calculatedChecksum){
+      fse.renameSync(path, path + ".old");
+    }
 
     return new Downloader(url, path)
       .then(function(f) {

--- a/src/commands/fetch-binaries.js
+++ b/src/commands/fetch-binaries.js
@@ -91,11 +91,11 @@ function getBinary(name, url, checksum, platform) {
         
         if(platform === 'linux'){
           try{
-            fs.chmodSync(f, 644);
-            Log.info("Execution permission set for ", f);
+            fs.chmodSync(f, 0o775);
+            Log.info("Permissions set for ", f);
           }
           catch(err){
-            Log.error("Failed to set execution permission for ", err);
+            Log.error("Failed to set permissions for ", err);
           }
         }
         Log.success(name + " downloaded in", f);


### PR DESCRIPTION
To reduce the chance that changes in the build provider an hosted build of ffmpeg and ffprobe was set.
The fetch:binaries now uses the hosted version.
Binaries url are now explicit in the package.json for each OS, as well as checksum
Checksum are used to verify that existing binaries have the expected version.

Closes #2 